### PR TITLE
Add locale selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,19 @@
 var axios = require("axios");
 
 module.exports = class Justwatch {
-  constructor() {}
+  constructor(locale = "en_US") {
+    this.locale = locale;
+  }
 
-  static async search(q,isPerson,n) {
+  async search(q,isPerson,n) {
     var type = isPerson?"person":"movie";
     n = +n || 15;
-    var data = await axios('https://apis.justwatch.com/content/titles/en_US/popular?body={"page_size":'+n+',"page":1,"query":"'+q.split(" ").join("+")+'","content_types":["'+type+'"]}');
+    var data = await axios('https://apis.justwatch.com/content/titles/"+locale+"/popular?body={"page_size":'+n+',"page":1,"query":"'+q.split(" ").join("+")+'","content_types":["'+type+'"]}');
     return data.data;
   }
 
-  static async get(id) {
-    var data = await axios("https://apis.justwatch.com/content/titles/movie/"+id+"/locale/en_IN");
+  async get(id) {
+    var data = await axios("https://apis.justwatch.com/content/titles/movie/"+id+"/locale/"+locale);
     return data.data;
   }
 }


### PR DESCRIPTION
The original repo uses two different (?) pre-set locales to fetch justwatch api data. This updates the repo to use a locale set on initialization.

This is a breaking change, as the functions in the constructor are no longer static. However I think it is more important to have customizability than to have static functions (without setup).

Please leave comments & make improvements!

Edit: Hyphenated “pre-set” for clarity